### PR TITLE
Document the chunk structure

### DIFF
--- a/main.c
+++ b/main.c
@@ -1084,6 +1084,14 @@ static void decode_ext_pcal(const uint8_t *data, const uint32_t len)
 	}
 }
 
+/*
+ * acTL
+ *
+ * offset   type    length   value
+ * -------------------------------
+ * 0 - 3    uint32    4      number of frames
+ * 4 - 7    uint32    4      number of looping (0=infinite looping)
+ */
 static void decode_apng_actl(const uint8_t *data, const uint32_t len)
 {
 	if (len != 8) {

--- a/main.c
+++ b/main.c
@@ -590,6 +590,16 @@ static void decode_itxt(const uint8_t *data, const uint32_t len)
 	printf("\tText (UTF-8) = ...");
 }
 
+/*
+ * zTXt (may appear more than one)
+ *
+ * offset   type    length   value
+ * -------------------------------
+ *   0      char    1 - 79   keyword (printable ascii)
+ *   n      uint8     1      null separator (\0)
+ *  n+1     uint8     1      compression method
+ *  n+2     uint8     m      compressed text (ascii)
+ */
 static void decode_ztxt(const uint8_t *data, const uint32_t len)
 {
 	uint32_t l = len, i = 0;

--- a/main.c
+++ b/main.c
@@ -697,6 +697,29 @@ static void decode_bkgd(const uint8_t *data, const uint32_t len)
 	}
 }
 
+/*
+ * sBIT
+ *
+ * if grayscale
+ * offset   type    length   value
+ * -------------------------------
+ *   0      uint8     1      significant bits for gray
+ *
+ * if indexed or rgb
+ * offset   type    length   value
+ * -------------------------------
+ *   0      uint8     1      significant bits for red
+ *   1      uint8     1      significant bits for green
+ *   2      uint8     1      significant bits for blue
+ *
+ * if grayscale+alpha or rgb+alpha
+ * offset   type    length   value
+ * -------------------------------
+ *   0      uint8     1      significant bits for red
+ *   1      uint8     1      significant bits for green
+ *   2      uint8     1      significant bits for blue
+ *   3      uint8     1      significant bits for alpha
+ */
 static void decode_sbit(const uint8_t *data, const uint32_t len)
 {
 	printf("\tSignificant bits = ");

--- a/main.c
+++ b/main.c
@@ -414,6 +414,13 @@ static void decode_srgb(const uint8_t *data, const uint32_t len)
 		printf("%d (Unknown intent)", intent);
 }
 
+/*
+ * gAMA
+ *
+ * offset   type    length   value
+ * -------------------------------
+ * 0 - 3    uint32    1      gamma value
+ */
 static void decode_gama(const uint8_t *data, const uint32_t len)
 {
 	if (len != 4) {

--- a/main.c
+++ b/main.c
@@ -435,6 +435,20 @@ static void decode_gama(const uint8_t *data, const uint32_t len)
 	printf("\tGamma = %01.05f", (float)__builtin_bswap32(gama) / 100000);
 }
 
+/*
+ * cHRM
+ *
+ * offset   type    length   value
+ * -------------------------------
+ * 0 - 3    uint32    4      white point x
+ * 4 - 7    uint32    4      white point y
+ * 8 - 11   uint32    4      red x
+ * 12 - 15  uint32    4      red y
+ * 16 - 19  uint32    4      green x
+ * 20 - 23  uint32    4      green y
+ * 24 - 27  uint32    4      blue x
+ * 28 - 31  uint32    4      blue y
+ */
 static void decode_chrm(const uint8_t *data, const uint32_t len)
 {
 	if (len != 32) {

--- a/main.c
+++ b/main.c
@@ -841,6 +841,25 @@ static void decode_trns(const uint8_t *data, const uint32_t len)
 	}
 }
 
+/*
+ * sPLT (may appear more than one)
+ *
+ * offset   type    length   value
+ * -------------------------------
+ *   0      char    1 - 79   palette name (printable ascii)
+ *   n      uint8     1      null separator (\0)
+ *  n+1     uint8     1      sample depth (8,16)
+ *  n+2    uint8/16  1/2     red color *
+ *  n+3    uint8/16  1/2     green color *
+ *  n+4    uint8/16  1/2     blue color *
+ *  n+5    uint8/16  1/2     alpha **
+ *  n+6    uint16     2      frequency **
+ *  ...
+ *
+ *  * = if sample depth is 8, then type is uint8 and each length is 1
+ *      otherwise, it's 16, then type is uint16 and each length is 2
+ *  ** = only appear if sample depth is 16
+ */
 static void decode_splt(const uint8_t *data, const uint32_t len)
 {
 	uint32_t l = len, i = 0;

--- a/main.c
+++ b/main.c
@@ -1006,6 +1006,23 @@ static void decode_ext_scal(const uint8_t *data, const uint32_t len)
 	printf(" (%s)", unit);
 }
 
+/*
+ * pCAL
+ *
+ * offset   type    length   value
+ * -------------------------------
+ *   0      char    1 - 79   calibration name (printable ascii)
+ *  n+1     uint8     1      null separator (\0)
+ *  n+2     int32     4      original zero (x0)
+ *  n+6     int32     4      original max (x1)
+ *  n+9     uint8     1      equation type (0,1,2,3)
+ *  n+10    uint8     1      number of parameters
+ *  n+11    char    0 - m    unit name (printable ascii)
+ *  m+1     uint8     1      null separator (\0)
+ *  m+2     char    1 - p    parameter 0 (p0) (floating-point ascii)
+ *  p+1     uint8     1      null separator (\0)
+ *  p+2     char    1 - o    parameter 1 (p1) (floating-point ascii)
+ */
 static void decode_ext_pcal(const uint8_t *data, const uint32_t len)
 {
 	uint32_t l = len, i = 0;

--- a/main.c
+++ b/main.c
@@ -1169,6 +1169,15 @@ static void decode_ext_gifx(const uint8_t *data, const uint32_t len)
 	printf("\tApplication data = .....");
 }
 
+/*
+ * gIFg
+ *
+ * offset   type    length   value
+ * -------------------------------
+ *   0      uint8     1      disposal method
+ *   1      uint8     1      user input flag
+ * 2 - 3    uint16    2      delay time
+ */
 static void decode_ext_gifg(const uint8_t *data, const uint32_t len)
 {
 	if (len != 4) {

--- a/main.c
+++ b/main.c
@@ -248,6 +248,22 @@ static void decode_ihdr(const uint8_t *data, const uint32_t len)
 	printf("\tInterlace = %u (%s interlace)", data[12], interlace);
 }
 
+/*
+ * PLTE
+ *
+ * n = chunk length
+ * palette entry = n / 3
+ *
+ * offset   type    length   value
+ * -------------------------------
+ *   0      uint8     1      red color
+ *   1      uint8     1      green color
+ *   2      uint8     1      blue color
+ *  ...
+ * n - 2    uint8     1      red color
+ * n - 1    uint8     1      green color
+ *   n      uint8     1      blue color
+ */
 static void decode_plte(const uint8_t *data, const uint32_t len)
 {
 	if (len % 3 != 0) {

--- a/main.c
+++ b/main.c
@@ -907,6 +907,18 @@ static void decode_splt(const uint8_t *data, const uint32_t len)
 	}
 }
 
+/*
+ * hIST
+ *
+ * entry = chunk length / 2
+ *
+ * offset   type    length   value
+ * -------------------------------
+ * 0 - 1    uint16    2      frequency of used for palette index 0
+ * 2 - 3    uint16    2      frequency of used for palette index 1
+ * 4 - 5    uint16    2      frequency of used for palette index 2
+ * ...
+ */
 static void decode_hist(const uint8_t *data, const uint32_t len)
 {
 	if (len % 2 != 0) {

--- a/main.c
+++ b/main.c
@@ -1195,6 +1195,13 @@ static void decode_ext_gifg(const uint8_t *data, const uint32_t len)
 	printf("\tDelay time = %lf seconds", (double).01 * delay_time);
 }
 
+/*
+ * sTER
+ *
+ * offset   type    length   value
+ * -------------------------------
+ *   0      uint8     1      layout mode (0=cross-fuse,1=diverging-fuse)
+ */
 static void decode_ext_ster(const uint8_t *data, const uint32_t len)
 {
 	if (len != 1) {

--- a/main.c
+++ b/main.c
@@ -1146,6 +1146,15 @@ static void decode_apng_fctl(const uint8_t *data, const uint32_t len)
 	printf("\tBlend = %u (%s)", buf3[1], blend);
 }
 
+/*
+ * gIFx
+ *
+ * offset   type    length   value
+ * -------------------------------
+ * 0 - 7    uint8     8      application identifier (printable ascii)
+ * 8 - 10   uint8     3      authentication code
+ *   11     ?????     n      application data
+ */
 static void decode_ext_gifx(const uint8_t *data, const uint32_t len)
 {
 	if (len < 11) {

--- a/main.c
+++ b/main.c
@@ -1111,6 +1111,21 @@ static void decode_apng_actl(const uint8_t *data, const uint32_t len)
 	printf("\tNumber of plays = %u %s", nplays, nplays == 0 ? "(infinite)" : "");
 }
 
+/*
+ * fcTL
+ *
+ * offset   type    length   value
+ * -------------------------------
+ * 0 - 3    uint32    4      sequence of chunk animation, start from 0
+ * 4 - 7    uint32    4      width frame
+ * 8 - 11   uint32    4      height frame
+ * 12 - 15  uint32    4      X position
+ * 16 - 19  uint32    4      Y position
+ * 20 - 21  uint16    2      frame delay fraction numerator
+ * 22 - 23  uint16    2      frame delay fraction denominator
+ *   24     uint8     1      frame disposal type (0,1,2)
+ *   25     uint8     1      frame blend type (0,1)
+ */
 static void decode_apng_fctl(const uint8_t *data, const uint32_t len)
 {
 	if (len != 26) {

--- a/main.c
+++ b/main.c
@@ -540,6 +540,21 @@ static void decode_text(const uint8_t *data, const uint32_t len)
 	}
 }
 
+/*
+ * iTXt (may appear more than one)
+ *
+ * offset   type    length   value
+ * -------------------------------
+ *   0      char    1 - 79   keyword (printable ascii)
+ *   n      uint8     1      null separator (\0)
+ *  n+1     uint8     1      compression flag (0=uncompress,1=compress)
+ *  n+2     uint8     1      compression method
+ *  n+3     char    0 - m    language tag (printable ascii)
+ *  m+1     uint8     1      null separator (\0)
+ *  m+2     utf8    0 - o    translated keyword (utf8)
+ *  o+1     uint8     1      null separator (\0)
+ *  o+2     utf8    0 - p    text (utf8 or compressed utf8)
+ */
 static void decode_itxt(const uint8_t *data, const uint32_t len)
 {
 	uint32_t l = len, i = 0;

--- a/main.c
+++ b/main.c
@@ -315,6 +315,18 @@ static void decode_idat(const uint8_t *data, const uint32_t len)
 #endif
 }
 
+/*
+ * tIME
+ *
+ * offset   type    length   value
+ * -------------------------------
+ * 0 - 1    uint16    2      year (example: 20,20)
+ *   2      uint8     1      month (min=1,max=12)
+ *   3      uint8     1      day (min=1,max=31)
+ *   4      uint8     1      hour (min=0,max=23)
+ *   5      uint8     1      minute (min=0,max=59)
+ *   6      uint8     1      second (min=0,max=60)
+ */
 static void decode_time(const uint8_t *data, const uint32_t len)
 {
 	if (len != 7) {

--- a/main.c
+++ b/main.c
@@ -943,6 +943,15 @@ static void decode_hist(const uint8_t *data, const uint32_t len)
 	}
 }
 
+/*
+ * oFFs
+ *
+ * offset   type    length   value
+ * -------------------------------
+ * 0 - 3    int32     4      x position
+ * 4 - 7    int32     4      y position
+ *   8      uint8     2      unit (0=pixel,1=micrometer)
+ */
 static void decode_ext_offs(const uint8_t *data, const uint32_t len)
 {
 	if (len != 9) {

--- a/main.c
+++ b/main.c
@@ -622,6 +622,26 @@ static void decode_ztxt(const uint8_t *data, const uint32_t len)
 		printf(".....");
 }
 
+/*
+ * bKGD
+ *
+ * if indexed color
+ * offset   type    length   value
+ * -------------------------------
+ *   0      uint8     1      palette index
+ *
+ * if grayscale or grayscale+alpha
+ * offset   type    length   value
+ * -------------------------------
+ * 0 - 1    uint16    2      gray level
+ *
+ * if rgb or rgb+alpha
+ * offset   type    length   value
+ * -------------------------------
+ * 0 - 1    uint16    2      red color
+ * 2 - 3    uint16    2      green color
+ * 4 - 5    uint16    2      blue color
+ */
 static void decode_bkgd(const uint8_t *data, const uint32_t len)
 {
 	printf("\t");

--- a/main.c
+++ b/main.c
@@ -352,6 +352,15 @@ static void decode_time(const uint8_t *data, const uint32_t len)
 		printf("\tLast modification = %s", buf);
 }
 
+/*
+ * pHYs
+ *
+ * offset   type    length   value
+ * -------------------------------
+ * 0 - 3    uint32    4      x axis
+ * 4 - 7    uint32    4      y axis
+ *   8      uint8     1      unit (0=pixel,1=meter)
+ */
 static void decode_phys(const uint8_t *data, const uint32_t len)
 {
 	if (len != 9) {

--- a/main.c
+++ b/main.c
@@ -382,6 +382,13 @@ static void decode_phys(const uint8_t *data, const uint32_t len)
 	printf("\t%u x %u pixels%s (approx. %u DPI)", x, y, unit, dpi);
 }
 
+/*
+ * sRGB
+ *
+ * offset   type    length   value
+ * -------------------------------
+ *   0      uint8     1      rendering intent (0,1,2,3)
+ */
 static void decode_srgb(const uint8_t *data, const uint32_t len)
 {
 	if (len != 1) {

--- a/main.c
+++ b/main.c
@@ -971,6 +971,16 @@ static void decode_ext_offs(const uint8_t *data, const uint32_t len)
 	printf("\tImage position = %d x %d %s", (int32_t)x, (int32_t)y, unit);
 }
 
+/*
+ * sCAL
+ *
+ * offset   type    length   value
+ * -------------------------------
+ *   0      uint8     1      unit (1=meter,2=radian)
+ *   1      char    1 - n    pixel width (ascii floating-point)
+ *  n+1     uint8     1      null separator (\0)
+ *  n+2     char    1 - m    pixel height (ascii floating-point)
+ */
 static void decode_ext_scal(const uint8_t *data, const uint32_t len)
 {
 	uint32_t l = len;

--- a/main.c
+++ b/main.c
@@ -508,6 +508,15 @@ static void decode_iccp(const uint8_t *data, const uint32_t len)
 		printf(".....");
 }
 
+/*
+ * tEXt (may appear more than one)
+ *
+ * offset   type    length   value
+ * -------------------------------
+ *   0      char    1 - 79   keyword (printable ascii)
+ *   n      uint8     1      null separator (\0)
+ *  n+1     char      m      text (printable ascii)
+ */
 static void decode_text(const uint8_t *data, const uint32_t len)
 {
 

--- a/main.c
+++ b/main.c
@@ -770,6 +770,29 @@ static void decode_sbit(const uint8_t *data, const uint32_t len)
 	}
 }
 
+/*
+ * tRNS
+ *
+ * if grayscale
+ * offset   type    length   value
+ * -------------------------------
+ * 0 - 1    uint16    2      transparency level for gray
+ *
+ * if indexed
+ * offset   type    length   value
+ * -------------------------------
+ *   0      uint8     1      transparency level for palette index 0
+ *   1      uint8     1      transparency level for palette index 1
+ *  ...
+ *   n      uint8     1      transparency level for palette index n
+ *
+ * if rgb
+ * offset   type    length   value
+ * -------------------------------
+ * 0 - 1    uint16    2      transparency level for red
+ * 2 - 3    uint16    2      transparency level for green
+ * 4 - 5    uint16    2      transparency level for blue
+ */
 static void decode_trns(const uint8_t *data, const uint32_t len)
 {
 	printf("\t");

--- a/main.c
+++ b/main.c
@@ -476,6 +476,16 @@ static void decode_chrm(const uint8_t *data, const uint32_t len)
 	printf("\tGreen y = %01.05f", (float)res[7] / 100000);
 }
 
+/*
+ * iCCP
+ *
+ * offset   type    length   value
+ * -------------------------------
+ *   0      char    1 - 79   profile name (printable ascii)
+ *   n      uint8     1      null separator (\0)
+ *  n+1     uint8     1      compression method (0)
+ *  n+2     uint8     m      compressed ICC profile
+ */
 static void decode_iccp(const uint8_t *data, const uint32_t len)
 {
 	uint32_t l = len, i = 0;


### PR DESCRIPTION
Only document chunks that have decoder (except IDAT)

- [x] IHDR
- [x] PLTE
- [x] tIME
- [x] pHYs
- [x] sRGB
- [x] gAMA
- [x]  cHRM
- [x] iCCP
- [x] tEXt
- [x] iTXt
- [x] zTXt
- [x] bKGD
- [x] sBIT
- [x] tRNS
- [x] sPLT
- [x] hIST
- [x] oFFs
- [x] sCAL
- [x] pCAL
- [x] gIFx
- [x] gIFg
- [x] sTER
- [x] acTL
- [x] fcTL